### PR TITLE
Make emoji rule work on real emoji

### DIFF
--- a/lib/normalize_opts.js
+++ b/lib/normalize_opts.js
@@ -3,6 +3,7 @@
 
 'use strict';
 
+var emojiRE = require('emoji-regex')();
 
 function quoteRE(str) {
   return str.replace(/[.?*+^$[\]\\(){}|-]/g, '\\$&');
@@ -46,6 +47,7 @@ module.exports = function normalize_opts(options) {
                 .sort()
                 .reverse()
                 .map(function (name) { return quoteRE(name); })
+                .concat(emojiRE.source)
                 .join('|');
   var scanRE = RegExp(names);
   var replaceRE = RegExp(names, 'g');

--- a/lib/replace.js
+++ b/lib/replace.js
@@ -7,6 +7,8 @@
 'use strict';
 
 
+var emojiRE = require('emoji-regex')();
+
 module.exports = function create_rule(md, emojies, shortcuts, scanRE, replaceRE) {
   var arrayReplaceAt = md.utils.arrayReplaceAt,
       ucm = md.utils.lib.ucmicro,
@@ -16,7 +18,7 @@ module.exports = function create_rule(md, emojies, shortcuts, scanRE, replaceRE)
     var token, last_pos = 0, nodes = [];
 
     text.replace(replaceRE, function (match, offset, src) {
-      var emoji_name;
+      var emoji, emoji_name;
       // Validate emoji name
       if (shortcuts.hasOwnProperty(match)) {
         // replace shortcut with full name
@@ -31,8 +33,13 @@ module.exports = function create_rule(md, emojies, shortcuts, scanRE, replaceRE)
         if (offset + match.length < src.length && !ZPCc.test(src[offset + match.length])) {
           return;
         }
+        emoji = emojies[emoji_name];
+      } else if (emojiRE.test(match)) {
+        emoji = match;
+        emoji_name = match;
       } else {
         emoji_name = match.slice(1, -1);
+        emoji = emojies[emoji_name];
       }
 
       // Add new tokens to pending list
@@ -44,7 +51,7 @@ module.exports = function create_rule(md, emojies, shortcuts, scanRE, replaceRE)
 
       token         = new Token('emoji', '', 0);
       token.markup  = emoji_name;
-      token.content = emojies[emoji_name];
+      token.content = emoji;
       nodes.push(token);
 
       last_pos = offset + match.length;

--- a/lib/replace.js
+++ b/lib/replace.js
@@ -7,7 +7,7 @@
 'use strict';
 
 
-var emojiRE = require('emoji-regex')();
+var emojiRE = require('emoji-regex');
 
 module.exports = function create_rule(md, emojies, shortcuts, scanRE, replaceRE) {
   var arrayReplaceAt = md.utils.arrayReplaceAt,
@@ -34,7 +34,7 @@ module.exports = function create_rule(md, emojies, shortcuts, scanRE, replaceRE)
           return;
         }
         emoji = emojies[emoji_name];
-      } else if (emojiRE.test(match)) {
+      } else if (emojiRE().test(match)) {
         emoji = match;
         emoji_name = match;
       } else {

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "mocha": "*",
     "request": "*",
     "uglify-js": "*"
+  },
+  "dependencies": {
+    "emoji-regex": "^6.5.0"
   }
 }

--- a/test/fixtures/output.txt
+++ b/test/fixtures/output.txt
@@ -1,0 +1,11 @@
+---
+desc: Custom output function
+---
+
+
+wraps shorthand, shortcuts, and emojis
+.
+:D :smile: 😄
+.
+<p><span>😄</span> <span>😄</span> <span>😄</span></p>
+.

--- a/test/fixtures/output.txt
+++ b/test/fixtures/output.txt
@@ -9,3 +9,9 @@ wraps shorthand, shortcuts, and emojis
 .
 <p><span>😄</span> <span>😄</span> <span>😄</span></p>
 .
+works with multiple emoji
+.
+😄😄😄
+.
+<p><span>😄</span><span>😄</span><span>😄</span></p>
+.

--- a/test/test.js
+++ b/test/test.js
@@ -70,6 +70,12 @@ describe('markdown-it-emoji-light', function () {
 
   md = markdownit({ linkify: true }).use(emoji);
   generate(path.join(__dirname, 'fixtures/autolinks.txt'), { header: true }, md);
+
+  md = markdownit().use(emoji);
+  md.renderer.rules.emoji = function (tokens, idx) {
+    return '<span>' + tokens[idx].content + '</span>';
+  };
+  generate(path.join(__dirname, 'fixtures/output.txt'), { header: true }, md);
 });
 
 


### PR DESCRIPTION
Sometimes markdown authors use real emoji, and it's incredibly useful to be able to change the output of real emoji as well as emojis that are the result of shorthand and shortcuts.

Uses https://github.com/mathiasbynens/emoji-regex, which could possibly be inlined if adding a dependency is a no-go.

Thanks for the great project!