### PR TITLE
Renderer option for twemoji and span

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2014 Vitaly Puzrin.
+Copyright (c) 2018 Ma_124, ma124.js.org
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Options are not mandatory:
 - __enabled__ (Array) - disable all emojis except whitelisted
 - __shortcuts__ (Object) - rewrite default shortcuts
   - example: `{ "smile": [ ":)", ":-)" ], "laughing": ":D" }`
+- __renderer__ (String) - Can be unicode (default), twemoji or span
+  - example: `"renderer": "span", "span_class_prefix": "emoji emoji_"`
 
 _Differences in browser._ If you load the script directly into the page without
 using a package system, the module will add itself globally with the name `markdownitEmoji`.
@@ -52,36 +54,6 @@ Init code will look a bit different in this case:
 
 ```js
 var md = window.markdownit().use(window.markdownitEmoji);
-```
-
-
-### change output
-
-By default, emojis are rendered as appropriate unicode chars. But you can change
-the renderer function as you wish.
-
-Render as span blocks (for example, to use a custom iconic font):
-
-```js
-// ...
-// initialize
-
-md.renderer.rules.emoji = function(token, idx) {
-  return '<span class="emoji emoji_' + token[idx].markup + '"></span>';
-};
-```
-
-Or use [twemoji](https://github.com/twitter/twemoji):
-
-```js
-// ...
-// initialize
-
-var twemoji = require('twemoji')
-
-md.renderer.rules.emoji = function(token, idx) {
-  return twemoji.parse(token[idx].content);
-};
 ```
 
 __NB 1__. Read [twemoji docs](https://github.com/twitter/twemoji#string-parsing)!

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var emojies_shortcuts = require('./lib/data/shortcuts');
 var emoji_html        = require('./lib/render');
 var emoji_replace     = require('./lib/replace');
 var normalize_opts    = require('./lib/normalize_opts');
+var twemoji           = null;
 
 
 module.exports = function emoji_plugin(md, options) {
@@ -17,7 +18,29 @@ module.exports = function emoji_plugin(md, options) {
 
   var opts = normalize_opts(md.utils.assign({}, defaults, options || {}));
 
-  md.renderer.rules.emoji = emoji_html;
+  if (options.renderer === 'unicode' || options.renderer === undefined || options.renderer === null) {
+    md.renderer.rules.emoji = (token, idx) => {
+      return tokens[idx].content;
+    };
+  } else if (options.renderer === 'twemoji') {
+    if (twemoji === null) {
+      twemoji = require('twemoji');
+    }
+    md.renderer.rules.emoji = (token, idx) => {
+      return twemoji.parse(token[idx].content)
+    };
+  } else if (options.renderer === 'span') {
+    if (options.span_class_prefix === undefined || options.span_class_prefix === null) {
+      options.span_class_prefix = "emoji emoji_";
+    }
+    md.renderer.rules.emoji = (token, idx) => {
+      return '<span class="' + options.span_class_prefix + token[idx].markup + '"></span>';
+    };
+  } else {
+    md.renderer.rules.emoji = (token, idx) => {
+      return "<!-- Unknown renderer option -->";
+    };
+  }
 
   md.core.ruler.push('emoji', emoji_replace(md, opts.defs, opts.shortcuts, opts.scanRE, opts.replaceRE));
 };

--- a/lib/render.js
+++ b/lib/render.js
@@ -1,5 +1,0 @@
-'use strict';
-
-module.exports = function emoji_html(tokens, idx /*, options, env */) {
-  return tokens[idx].content;
-};

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "mocha": "*",
     "request": "*",
     "uglify-js": "*"
+  },
+  "optionalDependencies": {
+    "twemoji": "^11.2.0"
   }
 }


### PR DESCRIPTION
Option to replace https://github.com/markdown-it/markdown-it-emoji/tree/fffd76a632c1ff5c7014156320a1db894a3a02e0#change-output
if `options.renderer == "twemoji"`: Twemoji (optional dependency) will be used
if `options.renderer = "span"`: `span_class_prefix` can be provided