### PR TITLE
Added "monocle_face"

### DIFF
--- a/lib/data/full.json
+++ b/lib/data/full.json
@@ -29,6 +29,7 @@
   "money_mouth_face": "🤑",
   "hugs": "🤗",
   "nerd_face": "🤓",
+  "monocle_face": "🧐",
   "sunglasses": "😎",
   "clown_face": "🤡",
   "cowboy_hat_face": "🤠",


### PR DESCRIPTION
`:monocle_face:` -> 🧐

It's supported in Github markdown: :monocle_face: