### PR TITLE
Add bare-version without included emojis or shortcuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,14 @@ browserify:
 	./node_modules/.bin/uglifyjs dist/markdown-it-emoji-light.js -b beautify=false,ascii-only=true -c -m \
 		--preamble "/*! ${NPM_PACKAGE} ${NPM_VERSION} ${GITHUB_PROJ} @license MIT */" \
 		> dist/markdown-it-emoji-light.min.js
+	# Browserify bare version
+	( printf "/*! ${NPM_PACKAGE} ${NPM_VERSION} ${GITHUB_PROJ} @license MIT */" ; \
+		./node_modules/.bin/browserify ./bare.js -s markdownitEmoji \
+		) > dist/markdown-it-emoji-bare.js
+	# Minify bare version
+	./node_modules/.bin/uglifyjs dist/markdown-it-emoji-bare.js -b beautify=false,ascii-only=true -c -m \
+		--preamble "/*! ${NPM_PACKAGE} ${NPM_VERSION} ${GITHUB_PROJ} @license MIT */" \
+		> dist/markdown-it-emoji-bare.min.js
 
 .PHONY: lint test  coverage
 .SILENT: lint test

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@
 
 __v1.+ requires `markdown-it` v4.+, see changelog.__
 
-Two versions:
+Three versions:
 
 - __Full__ (default), with all github supported emojis.
 - [Light](https://github.com/markdown-it/markdown-it-emoji/blob/master/lib/data/light.json), with only well-supported unicode emojis and reduced size.
+- Bare, without included emojis or shortcuts. This requires defining your own definitions and shortcuts. 
 
 Also supports emoticons [shortcuts](https://github.com/markdown-it/markdown-it-emoji/blob/master/lib/data/shortcuts.js) like `:)`, `:-(`, and others. See the full list in the link above.
 

--- a/bare.js
+++ b/bare.js
@@ -1,0 +1,21 @@
+'use strict';
+
+
+var emoji_html        = require('./lib/render');
+var emoji_replace     = require('./lib/replace');
+var normalize_opts    = require('./lib/normalize_opts');
+
+
+module.exports = function emoji_plugin(md, options) {
+  var defaults = {
+    defs: {},
+    shortcuts: {},
+    enabled: []
+  };
+
+  var opts = normalize_opts(md.utils.assign({}, defaults, options || {}));
+
+  md.renderer.rules.emoji = emoji_html;
+
+  md.core.ruler.push('emoji', emoji_replace(md, opts.defs, opts.shortcuts, opts.scanRE, opts.replaceRE));
+};

--- a/index.js
+++ b/index.js
@@ -3,9 +3,7 @@
 
 var emojies_defs      = require('./lib/data/full.json');
 var emojies_shortcuts = require('./lib/data/shortcuts');
-var emoji_html        = require('./lib/render');
-var emoji_replace     = require('./lib/replace');
-var normalize_opts    = require('./lib/normalize_opts');
+var bare_emoji_plugin = require('./bare');
 
 
 module.exports = function emoji_plugin(md, options) {
@@ -15,9 +13,7 @@ module.exports = function emoji_plugin(md, options) {
     enabled: []
   };
 
-  var opts = normalize_opts(md.utils.assign({}, defaults, options || {}));
+  var opts = md.utils.assign({}, defaults, options || {});
 
-  md.renderer.rules.emoji = emoji_html;
-
-  md.core.ruler.push('emoji', emoji_replace(md, opts.defs, opts.shortcuts, opts.scanRE, opts.replaceRE));
+  bare_emoji_plugin(md, opts);
 };

--- a/lib/normalize_opts.js
+++ b/lib/normalize_opts.js
@@ -39,14 +39,22 @@ module.exports = function normalize_opts(options) {
     return acc;
   }, {});
 
-  // Compile regexp
-  var names = Object.keys(emojies)
-    .map(function (name) { return ':' + name + ':'; })
-    .concat(Object.keys(shortcuts))
-    .sort()
-    .reverse()
-    .map(function (name) { return quoteRE(name); })
-    .join('|');
+  var keys = Object.keys(emojies),
+      names;
+
+  // If no definitions are given, return empty regex to avoid replacements with 'undefined'.
+  if (keys.length === 0) {
+    names = '^$';
+  } else {
+    // Compile regexp
+    names = keys
+      .map(function (name) { return ':' + name + ':'; })
+      .concat(Object.keys(shortcuts))
+      .sort()
+      .reverse()
+      .map(function (name) { return quoteRE(name); })
+      .join('|');
+  }
   var scanRE = RegExp(names);
   var replaceRE = RegExp(names, 'g');
 

--- a/light.js
+++ b/light.js
@@ -3,9 +3,7 @@
 
 var emojies_defs      = require('./lib/data/light.json');
 var emojies_shortcuts = require('./lib/data/shortcuts');
-var emoji_html        = require('./lib/render');
-var emoji_replace     = require('./lib/replace');
-var normalize_opts    = require('./lib/normalize_opts');
+var bare_emoji_plugin = require('./bare');
 
 
 module.exports = function emoji_plugin(md, options) {
@@ -15,9 +13,7 @@ module.exports = function emoji_plugin(md, options) {
     enabled: []
   };
 
-  var opts = normalize_opts(md.utils.assign({}, defaults, options || {}));
+  var opts = md.utils.assign({}, defaults, options || {});
 
-  md.renderer.rules.emoji = emoji_html;
-
-  md.core.ruler.push('emoji', emoji_replace(md, opts.defs, opts.shortcuts, opts.scanRE, opts.replaceRE));
+  bare_emoji_plugin(md, opts);
 };

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "files": [
     "index.js",
     "light.js",
+    "bare.js",
     "lib/",
     "dist/"
   ],
@@ -32,6 +33,6 @@
     "markdown-it-testgen": "~0.1.0",
     "mocha": "*",
     "request": "*",
-    "uglify-js": "*"
+    "uglify-js": "^2"
   }
 }

--- a/test/fixtures/bare.txt
+++ b/test/fixtures/bare.txt
@@ -1,0 +1,10 @@
+---
+desc: Bare version
+---
+
+don't convert emojis without definitions
+.
+:smile:
+.
+<p>:smile:</p>
+.

--- a/test/test.js
+++ b/test/test.js
@@ -9,7 +9,8 @@ var assert      = require('assert');
 var markdownit  = require('markdown-it');
 var generate    = require('markdown-it-testgen');
 
-var emoji       = require('..');
+var emoji_bare  = require('../bare');
+var emoji_full  = require('..');
 var emoji_light = require('../light');
 
 
@@ -17,13 +18,13 @@ describe('markdown-it-emoji', function () {
   var md;
 
 
-  md = markdownit().use(emoji);
+  md = markdownit().use(emoji_full);
   generate(path.join(__dirname, 'fixtures/default'), { header: true }, md);
 
   generate(path.join(__dirname, 'fixtures/full.txt'), { header: true }, md);
 
 
-  md = markdownit().use(emoji, {
+  md = markdownit().use(emoji_full, {
     defs: {
       one: '!!!one!!!',
       fifty: '!!50!!'
@@ -36,10 +37,10 @@ describe('markdown-it-emoji', function () {
   generate(path.join(__dirname, 'fixtures/options.txt'), { header: true }, md);
 
 
-  md = markdownit().use(emoji, { enabled: [ 'smile', 'grin' ] });
+  md = markdownit().use(emoji_full, { enabled: [ 'smile', 'grin' ] });
   generate(path.join(__dirname, 'fixtures/whitelist.txt'), { header: true }, md);
 
-  md = markdownit({ linkify: true }).use(emoji);
+  md = markdownit({ linkify: true }).use(emoji_full);
   generate(path.join(__dirname, 'fixtures/autolinks.txt'), { header: true }, md);
 });
 
@@ -68,8 +69,27 @@ describe('markdown-it-emoji-light', function () {
   md = markdownit().use(emoji_light, { enabled: [ 'smile', 'grin' ] });
   generate(path.join(__dirname, 'fixtures/whitelist.txt'), { header: true }, md);
 
-  md = markdownit({ linkify: true }).use(emoji);
+  md = markdownit({ linkify: true }).use(emoji_full);
   generate(path.join(__dirname, 'fixtures/autolinks.txt'), { header: true }, md);
+});
+
+describe('markdown-it-emoji-bare', function () {
+  var md;
+
+  md = markdownit().use(emoji_bare);
+  generate(path.join(__dirname, 'fixtures/bare.txt'), { header: true }, md);
+
+  md = markdownit().use(emoji_bare, {
+    defs: {
+      one: '!!!one!!!',
+      fifty: '!!50!!'
+    },
+    shortcuts: {
+      fifty: [ ':50', '|50' ],
+      one: ':uno'
+    }
+  });
+  generate(path.join(__dirname, 'fixtures/options.txt'), { header: true }, md);
 });
 
 


### PR DESCRIPTION
This PR introduces an export for a bare-version that does not ship the emoji or shortcut definitions alongside.
You might want to use it, if you're using custom definitions and want to keep the final bundle size as low as possible.

I had to set uglify-js in package.json to version 2, because the newer version 3 dropped support for the "preamble" parameter, resulting in failing build procedures.

Closes #41 