### PR TITLE
Replace unicode emoji characters, allowing them to be customized by renderer rules

### DIFF
--- a/lib/normalize_opts.mjs
+++ b/lib/normalize_opts.mjs
@@ -41,6 +41,7 @@ export default function normalize_opts (options) {
     names = keys
       .map(name => { return `:${name}:` })
       .concat(Object.keys(shortcuts))
+      .concat(Object.values(emojies))
       .sort()
       .reverse()
       .map(name => { return quoteRE(name) })

--- a/lib/replace.mjs
+++ b/lib/replace.mjs
@@ -28,15 +28,13 @@ export default function create_rule (md, emojies, shortcuts, scanRE, replaceRE) 
         if (offset + match.length < src.length && !ZPCc.test(src[offset + match.length])) {
           return
         }
-      } else if (match[0] === ':' && match[match.length-1] === ':') {
+      } else if (match[0] === ':' && match[match.length - 1] === ':') {
         // emoji_name specified like :smile:
         emoji_name = match.slice(1, -1)
       } else {
         // replace unicode emoji using canonical name
         emoji_name = emojies_rev[match]
       }
-
-      if (!emoji_name) { return }
 
       // Add new tokens to pending list
       if (offset > last_pos) {
@@ -91,7 +89,7 @@ export default function create_rule (md, emojies, shortcuts, scanRE, replaceRE) 
   }
 };
 
-function reverse_object(obj) {
+function reverse_object (obj) {
   return Object.fromEntries(Object
     .entries(obj)
     .map(([key, value]) => [value, key])

--- a/lib/replace.mjs
+++ b/lib/replace.mjs
@@ -8,6 +8,7 @@ export default function create_rule (md, emojies, shortcuts, scanRE, replaceRE) 
   const ucm = md.utils.lib.ucmicro
   const has = md.utils.has
   const ZPCc = new RegExp([ucm.Z.source, ucm.P.source, ucm.Cc.source].join('|'))
+  const emojies_rev = reverse_object(emojies)
 
   function splitTextToken (text, level, Token) {
     let last_pos = 0
@@ -27,9 +28,15 @@ export default function create_rule (md, emojies, shortcuts, scanRE, replaceRE) 
         if (offset + match.length < src.length && !ZPCc.test(src[offset + match.length])) {
           return
         }
-      } else {
+      } else if (match[0] === ':' && match[match.length-1] === ':') {
+        // emoji_name specified like :smile:
         emoji_name = match.slice(1, -1)
+      } else {
+        // replace unicode emoji using canonical name
+        emoji_name = emojies_rev[match]
       }
+
+      if (!emoji_name) { return }
 
       // Add new tokens to pending list
       if (offset > last_pos) {
@@ -83,3 +90,10 @@ export default function create_rule (md, emojies, shortcuts, scanRE, replaceRE) 
     }
   }
 };
+
+function reverse_object(obj) {
+  return Object.fromEntries(Object
+    .entries(obj)
+    .map(([key, value]) => [value, key])
+  )
+}

--- a/test/fixtures/renderer.txt
+++ b/test/fixtures/renderer.txt
@@ -1,0 +1,27 @@
+---
+desc: Wrap emojis using renderer rules
+---
+
+
+Replace emojis
+.
+before :smile: test __1__
+.
+<p>before <span class="emoji emoji_smile">😄</span> test <strong>1</strong></p>
+.
+
+
+alias + original
+.
+:) :smiley:
+.
+<p><span class="emoji emoji_smiley">😃</span> <span class="emoji emoji_smiley">😃</span></p>
+.
+
+
+Unicode emojies are also wrapped
+.
+aaa 😂 bbb 😊 ccc 😘 ddd
+.
+<p>aaa <span class="emoji emoji_joy">😂</span> bbb <span class="emoji emoji_blush">😊</span> ccc <span class="emoji emoji_kissing_heart">😘</span> ddd</p>
+.

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -111,3 +111,13 @@ describe('integrity', function () {
     }
   })
 })
+
+describe('renderer rules', function () {
+  const md = markdownit().use(emoji_full)
+
+  md.renderer.rules.emoji = function (tokens, idx) {
+    return '<span class="emoji emoji_' + tokens[idx].markup + '">' + tokens[idx].content + '</span>'
+  }
+
+  generate(fileURLToPath(new URL('fixtures/renderer.txt', import.meta.url)), { header: true }, md)
+})


### PR DESCRIPTION
A very straightforward implementation of #43.  "It just works!"
I'm sure it's possible to provide an option to control this behavior, but it doesn't seem necessary.
