### PR TITLE
Add `mergeDefs` and `mergeShortcuts` options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,15 @@ Options are not mandatory:
 
 - __defs__ (Object) - rewrite available emoji definitions
   - example: `{ name1: char1, name2: char2, ... }`
+
+  By default, this **replaces** the entire definitions map.  
+  If you want to only override some of them and keep the rest, set `mergeDefs: true`.
 - __enabled__ (Array) - disable all emojis except whitelisted
 - __shortcuts__ (Object) - rewrite default shortcuts
   - example: `{ "smile": [ ":)", ":-)" ], "laughing": ":D" }`
+
+  By default, this **replaces** all shortcuts.  
+  If you want to extend/override instead, set `mergeShortcuts: true`.
 
 _Differences in browser._ If you load the script directly into the page without
 using a package system, the module will add itself globally with the name `markdownitEmoji`.

--- a/lib/full.mjs
+++ b/lib/full.mjs
@@ -6,10 +6,20 @@ export default function emoji_plugin (md, options) {
   const defaults = {
     defs: emojies_defs,
     shortcuts: emojies_shortcuts,
-    enabled: []
+    enabled: [],
+    mergeDefs: true,
+    mergeShortcuts: true
   }
 
   const opts = md.utils.assign({}, defaults, options || {})
+
+  if (opts.mergeDefs && options && options.defs) {
+      opts.defs = md.utils.assign({}, defaults.defs, options.defs)
+  }
+
+  if (opts.mergeShortcuts && options && options.shortcuts) {
+      opts.shortcuts = md.utils.assign({}, defaults.shortcuts, options.shortcuts)
+  }
 
   bare_emoji_plugin(md, opts)
 };

--- a/lib/light.mjs
+++ b/lib/light.mjs
@@ -6,10 +6,20 @@ export default function emoji_plugin (md, options) {
   const defaults = {
     defs: emojies_defs,
     shortcuts: emojies_shortcuts,
-    enabled: []
+    enabled: [],
+    mergeDefs: true,
+    mergeShortcuts: true
   }
 
   const opts = md.utils.assign({}, defaults, options || {})
+
+  if (opts.mergeDefs && options && options.defs) {
+    opts.defs = md.utils.assign({}, defaults.defs, options.defs)
+  }
+
+  if (opts.mergeShortcuts && options && options.shortcuts) {
+    opts.shortcuts = md.utils.assign({}, defaults.shortcuts, options.shortcuts)
+  }
 
   bare_emoji_plugin(md, opts)
 };


### PR DESCRIPTION
When true, user overrides extend the preset maps instead of replacing them.